### PR TITLE
Small fixes and black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cloudpickle>=2.1.0
 imageio
 numpy>=1.19
 pydantic>=1.8.2
-sklearn
+scikit-learn
 scipy>=1.7.1
 torch>=1.10.1
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "imageio",
         "numpy>=1.19",
         "pydantic>=1.8.2",
-        "sklearn",
+        "scikit-learn",
         "scipy>=1.7.1",
         "torch>=1.10.1",
         "tqdm",

--- a/src/pythae/models/msssim_vae/msssim_vae_model.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_model.py
@@ -45,9 +45,7 @@ class MSSSIM_VAE(VAE):
 
         self.model_name = "MSSSIM_VAE"
         self.beta = model_config.beta
-        self.msssim = MSSSIM(
-            input_dim=model_config.input_dim, window_size=model_config.window_size
-        )
+        self.msssim = MSSSIM(window_size=model_config.window_size)
 
     def forward(self, inputs: BaseDataset, **kwargs):
         """

--- a/src/pythae/models/msssim_vae/msssim_vae_model.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_model.py
@@ -45,7 +45,9 @@ class MSSSIM_VAE(VAE):
 
         self.model_name = "MSSSIM_VAE"
         self.beta = model_config.beta
-        self.msssim = MSSSIM(input_dim=model_config.input_dim, window_size=model_config.window_size)
+        self.msssim = MSSSIM(
+            input_dim=model_config.input_dim, window_size=model_config.window_size
+        )
 
     def forward(self, inputs: BaseDataset, **kwargs):
         """

--- a/src/pythae/models/msssim_vae/msssim_vae_utils.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+
 class MSSSIM(torch.nn.Module):
     def __init__(self, input_dim, window_size=11):
         super(MSSSIM, self).__init__()
@@ -13,7 +14,7 @@ class MSSSIM(torch.nn.Module):
     def _gaussian(self, sigma):
         gauss = torch.Tensor(
             [
-                np.exp(-((x - self.window_size // 2) ** 2) / float(2 * sigma ** 2))
+                np.exp(-((x - self.window_size // 2) ** 2) / float(2 * sigma**2))
                 for x in range(self.window_size)
             ]
         )
@@ -23,13 +24,22 @@ class MSSSIM(torch.nn.Module):
         _1D_window = self._gaussian(1.5).unsqueeze(1)
         _2D_window = _1D_window.mm(_1D_window.t()).float()
 
-        _3D_window = torch.stack([ _2D_window * x for x in _1D_window],dim=2).float().unsqueeze(0).unsqueeze(0)
+        _3D_window = (
+            torch.stack([_2D_window * x for x in _1D_window], dim=2)
+            .float()
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
         _2D_window = _2D_window.unsqueeze(0).unsqueeze(0)
 
         if self.n_dim == 3:
-            return _3D_window.expand(channel, 1, self.window_size, self.window_size,self.window_size).contiguous()
+            return _3D_window.expand(
+                channel, 1, self.window_size, self.window_size, self.window_size
+            ).contiguous()
         else:
-            return _2D_window.expand(channel, 1, self.window_size, self.window_size).contiguous()
+            return _2D_window.expand(
+                channel, 1, self.window_size, self.window_size
+            ).contiguous()
 
     def ssim(self, img1: torch.Tensor, img2: torch.Tensor):
 
@@ -51,9 +61,15 @@ class MSSSIM(torch.nn.Module):
         mu2_sq = mu2.pow(2)
         mu1_mu2 = mu1 * mu2
 
-        sigma1_sq = convFunction(img1 * img1, window, padding=padd, groups=channel) - mu1_sq
-        sigma2_sq = convFunction(img2 * img2, window, padding=padd, groups=channel) - mu2_sq
-        sigma12 = convFunction(img1 * img2, window, padding=padd, groups=channel) - mu1_mu2
+        sigma1_sq = (
+            convFunction(img1 * img1, window, padding=padd, groups=channel) - mu1_sq
+        )
+        sigma2_sq = (
+            convFunction(img2 * img2, window, padding=padd, groups=channel) - mu2_sq
+        )
+        sigma12 = (
+            convFunction(img1 * img2, window, padding=padd, groups=channel) - mu1_mu2
+        )
 
         L = 1  # data already in [0, 1]
         C1 = (0.01 * L) ** 2
@@ -69,17 +85,16 @@ class MSSSIM(torch.nn.Module):
         return ret, cs
 
     def forward(self, img1, img2):
-
-        if img1.shape[-1] < 4:
+        if min(img1.shape[1:]) < 4:
             weights = torch.FloatTensor([1.0]).to(img1.device)
 
-        elif img1.shape[-1] < 8:
+        elif min(img1.shape[1:]) < 8:
             weights = torch.FloatTensor([0.3222, 0.6778]).to(img1.device)
 
-        elif img1.shape[-1] < 16:
+        elif min(img1.shape[1:]) < 16:
             weights = torch.FloatTensor([0.4558, 0.1633, 0.3809]).to(img1.device)
 
-        elif img1.shape[-1] < 32:
+        elif min(img1.shape[1:]) < 32:
             weights = torch.FloatTensor([0.3117, 0.3384, 0.2675, 0.0824]).to(
                 img1.device
             )
@@ -114,8 +129,8 @@ class MSSSIM(torch.nn.Module):
         mssim = (mssim + 1) / 2
         mcs = (mcs + 1) / 2
 
-        pow1 = mcs ** weights
-        pow2 = mssim ** weights
+        pow1 = mcs**weights
+        pow2 = mssim**weights
 
         output = torch.prod(pow1[:-1] * pow2[-1])
         return 1 - output

--- a/src/pythae/models/msssim_vae/msssim_vae_utils.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_utils.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 
 class MSSSIM(torch.nn.Module):
-    def __init__(self, input_dim, window_size=11):
+    def __init__(self, window_size=11):
         super(MSSSIM, self).__init__()
         self.window_size = window_size
 

--- a/src/pythae/models/msssim_vae/msssim_vae_utils.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_utils.py
@@ -9,7 +9,6 @@ class MSSSIM(torch.nn.Module):
     def __init__(self, input_dim, window_size=11):
         super(MSSSIM, self).__init__()
         self.window_size = window_size
-        self.n_dim = len(input_dim) - 1
 
     def _gaussian(self, sigma):
         gauss = torch.Tensor(
@@ -20,7 +19,7 @@ class MSSSIM(torch.nn.Module):
         )
         return gauss / gauss.sum()
 
-    def _create_window(self, channel=1):
+    def _create_window(self, n_dim, channel=1):
         _1D_window = self._gaussian(1.5).unsqueeze(1)
         _2D_window = _1D_window.mm(_1D_window.t()).float()
 
@@ -32,7 +31,7 @@ class MSSSIM(torch.nn.Module):
         )
         _2D_window = _2D_window.unsqueeze(0).unsqueeze(0)
 
-        if self.n_dim == 3:
+        if n_dim == 3:
             return _3D_window.expand(
                 channel, 1, self.window_size, self.window_size, self.window_size
             ).contiguous()
@@ -42,17 +41,17 @@ class MSSSIM(torch.nn.Module):
             ).contiguous()
 
     def ssim(self, img1: torch.Tensor, img2: torch.Tensor):
-
+        n_dim = len(img1.shape) - 2
         padd = int(self.window_size / 2)
 
-        if self.n_dim == 2:
+        if n_dim == 2:
             (_, channel, height, width) = img1.size()
             convFunction = F.conv2d
-        elif self.n_dim == 3:
+        elif n_dim == 3:
             (_, channel, height, width, depth) = img1.size()
             convFunction = F.conv3d
 
-        window = self._create_window(channel=channel).to(img1.device)
+        window = self._create_window(n_dim=n_dim, channel=channel).to(img1.device)
 
         mu1 = convFunction(img1, window, padding=padd, groups=channel)
         mu2 = convFunction(img2, window, padding=padd, groups=channel)
@@ -85,16 +84,17 @@ class MSSSIM(torch.nn.Module):
         return ret, cs
 
     def forward(self, img1, img2):
-        if min(img1.shape[1:]) < 4:
+        n_dim = len(img1.shape) - 2
+        if min(img1.shape[-n_dim:]) < 4:
             weights = torch.FloatTensor([1.0]).to(img1.device)
 
-        elif min(img1.shape[1:]) < 8:
+        elif min(img1.shape[-n_dim:]) < 8:
             weights = torch.FloatTensor([0.3222, 0.6778]).to(img1.device)
 
-        elif min(img1.shape[1:]) < 16:
+        elif min(img1.shape[-n_dim:]) < 16:
             weights = torch.FloatTensor([0.4558, 0.1633, 0.3809]).to(img1.device)
 
-        elif min(img1.shape[1:]) < 32:
+        elif min(img1.shape[-n_dim:]) < 32:
             weights = torch.FloatTensor([0.3117, 0.3384, 0.2675, 0.0824]).to(
                 img1.device
             )
@@ -107,10 +107,10 @@ class MSSSIM(torch.nn.Module):
         mssim = []
         mcs = []
 
-        pool_size = [2] * self.n_dim
-        if self.n_dim == 2:
+        pool_size = [2] * n_dim
+        if n_dim == 2:
             pool_function = F.avg_pool2d
-        elif self.n_dim == 3:
+        elif n_dim == 3:
             pool_function = F.avg_pool3d
 
         for _ in range(levels):

--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -221,7 +221,7 @@ class BaseTrainer:
                     cuda_inputs[key] = inputs[key].cuda()
 
                 else:
-                    cuda_inputs = inputs[key]
+                    cuda_inputs[key] = inputs[key]
             inputs_on_device = cuda_inputs
 
         return inputs_on_device


### PR DESCRIPTION
Hi @ravih18,
Thank you so much for your contribution in [this PR](https://github.com/clementchadebec/benchmark_VAE/pull/69). I have just looked at it and tried with 3D images. It seems to work just fine! I have just made a couple of adjustments:
- Removed the `self.n_dim` and compute the dimension of the images on the fly. In certain cases, users are not required to provide the input dimension (*e.g.* if they define their own architectures) and so the `MSSSIM` module cannot take the input dimension as input. 
- Change the check for the input size [here](https://github.com/clementchadebec/benchmark_VAE/blob/cc97046419464dbe0e7e9a1dea5cf817b268581e/src/pythae/models/msssim_vae/msssim_vae_utils.py#L88-L100) by checking the minimum over all the dimensions of the image. I only checked the last dimension before and this caused issues with non-square images.
- I merged the latest changes from main.
- I applied `black` formatting. 
 
If you are fine with them, you can merge them in your branch and I will then merge everything on the `main` branch.

Thanks again!

Have a nice week-end,

Clément 